### PR TITLE
Add Option to Hide Menu Bar Icon

### DIFF
--- a/ballast.xcodeproj/project.pbxproj
+++ b/ballast.xcodeproj/project.pbxproj
@@ -8,9 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1A7C470D213D6DBF00B25E04 /* Repeat.framework.dSYM in Resources */ = {isa = PBXBuildFile; fileRef = 1A7C470B213D6DBF00B25E04 /* Repeat.framework.dSYM */; };
-		1A7C470E213D6DBF00B25E04 /* Repeat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7C470C213D6DBF00B25E04 /* Repeat.framework */; };
-		1A7C470F213D6E5300B25E04 /* Repeat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7C470C213D6DBF00B25E04 /* Repeat.framework */; };
 		1A7C4710213D6E5300B25E04 /* Repeat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7C470C213D6DBF00B25E04 /* Repeat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1A81D82D21AEF179009612BB /* Repeat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7C470C213D6DBF00B25E04 /* Repeat.framework */; };
 		1A8352622125281A0087AA4E /* AudioAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8352612125281A0087AA4E /* AudioAPI.swift */; };
 		1A95F97821258A9B00F1E21E /* BalanceObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A95F97721258A9B00F1E21E /* BalanceObserver.swift */; };
 		1AA48E192125D576006DFA25 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 45EC38E31F9F510200C20FBB /* Assets.xcassets */; };
@@ -57,14 +56,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				456EF1C31FA55CBB0042FB56 /* LaunchAtLogin.framework in Frameworks */,
-				1A7C470F213D6E5300B25E04 /* Repeat.framework in Frameworks */,
-				1A7C470E213D6DBF00B25E04 /* Repeat.framework in Frameworks */,
+				1A81D82D21AEF179009612BB /* Repeat.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1A81D82C21AEF179009612BB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		45EC38D51F9F510200C20FBB = {
 			isa = PBXGroup;
 			children = (
@@ -73,6 +78,7 @@
 				456EF1C21FA55CBB0042FB56 /* LaunchAtLogin.framework */,
 				45EC38E01F9F510200C20FBB /* ballast */,
 				45EC38DF1F9F510200C20FBB /* Products */,
+				1A81D82C21AEF179009612BB /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/ballast/AppDelegate.swift
+++ b/ballast/AppDelegate.swift
@@ -17,4 +17,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ aNotification: Notification) {
         
     }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if (sharedStatusMenuController.isRunningInBackground()) {
+            sharedStatusMenuController.showRunningInBackgroundPrompt()
+        }
+
+        return true
+    }
 }

--- a/ballast/Base.lproj/MainMenu.xib
+++ b/ballast/Base.lproj/MainMenu.xib
@@ -22,10 +22,11 @@
                 <outlet property="balanceCorrectedItem" destination="8XO-As-Ozt" id="UPd-Sn-UrB"/>
                 <outlet property="disableBallastItem" destination="rFj-U3-MSg" id="u3G-nO-Dj8"/>
                 <outlet property="launchAtLoginItem" destination="Hva-YQ-ESE" id="8ak-WP-nTn"/>
+                <outlet property="runningInBackgroundWindow" destination="2XB-kv-nsM" id="20V-R3-10E"/>
                 <outlet property="statusMenu" destination="8GQ-Qj-wfB" id="QD4-Mw-Jpd"/>
             </connections>
         </customObject>
-        <window title="About Ballast" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="5y2-P8-0cD">
+        <window title="About Ballast" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="5y2-P8-0cD">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="283" y="305" width="480" height="270"/>
@@ -121,5 +122,57 @@
             </items>
             <point key="canvasLocation" x="133.5" y="142.5"/>
         </menu>
+        <window title="Ballast" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="2XB-kv-nsM" userLabel="Running in Background Menu">
+            <windowStyleMask key="styleMask" titled="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="283" y="305" width="480" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" id="qUr-df-dfQ">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i0I-wb-mTH">
+                        <rect key="frame" x="85" y="176" width="310" height="48"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Ballast is currently running in the background and keeping your balance centered." id="CoA-kL-aIv">
+                            <font key="font" size="14" name=".SFNSText"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wQM-4o-phB">
+                        <rect key="frame" x="104" y="101" width="273" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Show app in menu bar" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vUR-u2-zJB">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="stopRunningInBackgroundClicked:" target="KZu-Ba-O5Y" id="h5B-jt-PR1"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qJ6-zY-wIa">
+                        <rect key="frame" x="91" y="130" width="304" height="42"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="The app's menu bar icon is hidden." id="J2C-cf-1wr">
+                            <font key="font" size="14" name=".SFNSText"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bim-Je-5cY">
+                        <rect key="frame" x="104" y="68" width="273" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Or keep app hidden in background" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="juW-i4-eXo">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="keepRunningInBackgroundClicked:" target="KZu-Ba-O5Y" id="GYT-PS-Qaa"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+        </window>
     </objects>
 </document>

--- a/ballast/Base.lproj/MainMenu.xib
+++ b/ballast/Base.lproj/MainMenu.xib
@@ -23,7 +23,8 @@
                 <outlet property="disableBallastItem" destination="rFj-U3-MSg" id="u3G-nO-Dj8"/>
                 <outlet property="launchAtLoginItem" destination="Hva-YQ-ESE" id="8ak-WP-nTn"/>
                 <outlet property="runningInBackgroundWindow" destination="2XB-kv-nsM" id="20V-R3-10E"/>
-                <outlet property="statusMenu" destination="8GQ-Qj-wfB" id="QD4-Mw-Jpd"/>
+                <outlet property="runningInBackgroundWindowIcon" destination="WRM-1L-0Rs" id="3Km-Zy-H9k"/>
+                <outlet property="statusMenu" destination="8GQ-Qj-wfB" id="XFX-Kc-ePL"/>
             </connections>
         </customObject>
         <window title="About Ballast" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="5y2-P8-0cD">
@@ -106,6 +107,12 @@
                         <action selector="resetCorrectionCountClicked:" target="KZu-Ba-O5Y" id="wdE-Mb-cAo"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Hide Menu Bar Icon" id="d0L-Io-jri" userLabel="Hide Menu Bar Icon">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="hideStatusMenuIcon:" target="KZu-Ba-O5Y" id="Soq-bL-cUK"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="SCp-cz-BtN"/>
                 <menuItem title="About" id="8Pg-AB-FRZ">
                     <modifierMask key="keyEquivalentModifierMask"/>
@@ -125,14 +132,14 @@
         <window title="Ballast" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="2XB-kv-nsM" userLabel="Running in Background Menu">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="283" y="305" width="480" height="270"/>
+            <rect key="contentRect" x="283" y="305" width="480" height="305"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="qUr-df-dfQ">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <rect key="frame" x="0.0" y="0.0" width="480" height="305"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i0I-wb-mTH">
-                        <rect key="frame" x="85" y="176" width="310" height="48"/>
+                        <rect key="frame" x="85" y="149" width="310" height="48"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Ballast is currently running in the background and keeping your balance centered." id="CoA-kL-aIv">
                             <font key="font" size="14" name=".SFNSText"/>
@@ -141,7 +148,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wQM-4o-phB">
-                        <rect key="frame" x="104" y="101" width="273" height="32"/>
+                        <rect key="frame" x="104" y="68" width="273" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Show app in menu bar" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vUR-u2-zJB">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -152,7 +159,7 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qJ6-zY-wIa">
-                        <rect key="frame" x="91" y="130" width="304" height="42"/>
+                        <rect key="frame" x="91" y="103" width="304" height="42"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="The app's menu bar icon is hidden." id="J2C-cf-1wr">
                             <font key="font" size="14" name=".SFNSText"/>
@@ -161,7 +168,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bim-Je-5cY">
-                        <rect key="frame" x="104" y="68" width="273" height="32"/>
+                        <rect key="frame" x="104" y="33" width="273" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Or keep app hidden in background" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="juW-i4-eXo">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -171,8 +178,14 @@
                             <action selector="keepRunningInBackgroundClicked:" target="KZu-Ba-O5Y" id="GYT-PS-Qaa"/>
                         </connections>
                     </button>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WRM-1L-0Rs">
+                        <rect key="frame" x="216" y="216" width="48" height="48"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="tHH-Fb-7j1"/>
+                    </imageView>
                 </subviews>
             </view>
+            <point key="canvasLocation" x="139" y="695.5"/>
         </window>
     </objects>
 </document>

--- a/ballast/Info.plist
+++ b/ballast/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0-beta</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ballast/Info.plist
+++ b/ballast/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0-beta</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ballast/StatusMenuController.swift
+++ b/ballast/StatusMenuController.swift
@@ -86,7 +86,7 @@ class StatusMenuController: NSObject {
     }
 
     func showRunningInBackgroundPrompt () {
-        // Attempting to always bring about window to front
+        // Attempting to always bring prompt to front
         runningInBackgroundWindow?.close()
         runningInBackgroundWindow.setIsVisible(true)
         runningInBackgroundWindow.orderFrontRegardless()
@@ -173,12 +173,10 @@ class StatusMenuController: NSObject {
     }
     
     @IBAction func keepRunningInBackgroundClicked(_ sender: NSButton) {
-        // Attempting to always bring about window to front
         runningInBackgroundWindow?.close()
     }
     
     @IBAction func stopRunningInBackgroundClicked(_ sender: NSButton) {
-        // Attempting to always bring about window to front
         runningInBackgroundWindow?.close()
         self.toggleRunInBackground(false)
     }

--- a/ballast/StatusMenuController.swift
+++ b/ballast/StatusMenuController.swift
@@ -28,8 +28,7 @@ class StatusMenuController: NSObject {
     @IBOutlet weak var aboutWindow: NSWindow!
     @IBOutlet weak var aboutWindowVersionText: NSTextField!
     
-    var isEnabled = true
-
+    var isCenteringEnabled = true
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     let balanceCorrectedKey = "balanceChanged"
     let centerBalance: Float32 = 0.5
@@ -47,7 +46,7 @@ class StatusMenuController: NSObject {
         statusItem.image = icon
 
         statusItem.menu = statusMenu
-        isEnabled = true
+        isCenteringEnabled = true
 
         aboutWindowVersionText.stringValue = "Ballast @ Version \(Bundle.main.releaseVersionNumber!)"
 
@@ -88,7 +87,7 @@ class StatusMenuController: NSObject {
     }
 
     private func updateBalanceCorrectedItemTitle () {
-        if (self.isEnabled) {
+        if (self.isCenteringEnabled) {
             let count = UserDefaults.standard.integer(forKey: balanceCorrectedKey)
             balanceCorrectedItem.title = "Balance has been corrected \(count) time\(count == 1 ? "" : "s")"
         }
@@ -107,7 +106,7 @@ class StatusMenuController: NSObject {
     }
     
     private func updateDisabledState () {
-        disableBallastItem.state = self.isEnabled ? NSControl.StateValue.off : NSControl.StateValue.on
+        disableBallastItem.state = self.isCenteringEnabled ? NSControl.StateValue.off : NSControl.StateValue.on
     }
 
     @IBAction func launchAtLoginClicked(_ sender: NSMenuItem) {
@@ -122,10 +121,10 @@ class StatusMenuController: NSObject {
     }
     
     @IBAction func disableClicked(_ sender: NSMenuItem) {
-        self.isEnabled = !self.isEnabled
+        self.isCenteringEnabled = !self.isCenteringEnabled
         self.updateDisabledState()
 
-        if (self.isEnabled) {
+        if (self.isCenteringEnabled) {
             self.startBalanceObserving()
             self.updateBalanceCorrectedItemTitle()
         } else {

--- a/ballast/StatusMenuController.swift
+++ b/ballast/StatusMenuController.swift
@@ -27,6 +27,7 @@ class StatusMenuController: NSObject {
     @IBOutlet weak var launchAtLoginItem: NSMenuItem!
     @IBOutlet weak var aboutWindow: NSWindow!
     @IBOutlet weak var runningInBackgroundWindow: NSWindow!
+    @IBOutlet weak var runningInBackgroundWindowIcon: NSImageView!
     @IBOutlet weak var aboutWindowVersionText: NSTextField!
     
     var isCenteringEnabled = true
@@ -48,14 +49,17 @@ class StatusMenuController: NSObject {
         
         icon?.isTemplate = true
         statusItem.image = icon
+        runningInBackgroundWindowIcon.image = NSImage(named: NSImage.Name(rawValue: "AppIcon"))
+
 
         statusItem.menu = statusMenu
         isCenteringEnabled = true
 
         aboutWindowVersionText.stringValue = "Ballast @ Version \(Bundle.main.releaseVersionNumber!)"
         
+        // Continue hiding status menu icon, if set to run in background
         if (self.isRunningInBackground()) {
-            self.showRunningInBackgroundPrompt()
+            self.toggleRunInBackground(true);
         }
 
         self.updateLaunchAtLoginItemState()
@@ -68,6 +72,17 @@ class StatusMenuController: NSObject {
         debouncedCenterDefaultDeviceBalance.callback = {
             self.centerDefaultDeviceBalance()
         }
+    }
+
+    func isRunningInBackground () -> Bool {
+        return UserDefaults.standard.bool(forKey: runInBackgroundKey)
+    }
+
+    func showRunningInBackgroundPrompt () {
+        // Attempting to always bring about window to front
+        runningInBackgroundWindow?.close()
+        runningInBackgroundWindow.setIsVisible(true)
+        runningInBackgroundWindow.orderFrontRegardless()
     }
 
     @objc func centerDefaultDeviceBalance () {
@@ -121,10 +136,6 @@ class StatusMenuController: NSObject {
         disableBallastItem.state = self.isCenteringEnabled ? NSControl.StateValue.off : NSControl.StateValue.on
     }
     
-    private func isRunningInBackground () -> Bool {
-        return UserDefaults.standard.bool(forKey: runInBackgroundKey)
-    }
-    
     private func toggleRunInBackground (_ toggle: Bool) {
         UserDefaults.standard.set(toggle, forKey: runInBackgroundKey)
         self.toggleStatusMenuIcon(show: !toggle)
@@ -154,13 +165,6 @@ class StatusMenuController: NSObject {
         }
     }
     
-    private func showRunningInBackgroundPrompt () {
-        // Attempting to always bring about window to front
-        runningInBackgroundWindow?.close()
-        runningInBackgroundWindow.setIsVisible(true)
-        runningInBackgroundWindow.orderFrontRegardless()
-    }
-    
     @IBAction func keepRunningInBackgroundClicked(_ sender: NSButton) {
         // Attempting to always bring about window to front
         runningInBackgroundWindow?.close()
@@ -182,6 +186,10 @@ class StatusMenuController: NSObject {
     @IBAction func resetCorrectionCountClicked(_ sender: NSMenuItem) {
         UserDefaults.standard.set(0, forKey: balanceCorrectedKey)
         updateBalanceCorrectedItemTitle()
+    }
+
+    @IBAction func hideStatusMenuIcon(_ sender: NSMenuItem) {
+        toggleRunInBackground(true)
     }
 
     @IBAction func viewOnGitHubClicked(_ sender: NSButton) {

--- a/ballast/StatusMenuController.swift
+++ b/ballast/StatusMenuController.swift
@@ -20,6 +20,8 @@ extension Bundle {
     }
 }
 
+var sharedStatusMenuController = StatusMenuController()
+
 class StatusMenuController: NSObject {
     @IBOutlet weak var statusMenu: NSMenu!
     @IBOutlet weak var balanceCorrectedItem: NSMenuItem!
@@ -47,6 +49,11 @@ class StatusMenuController: NSObject {
     override func awakeFromNib() {
         let icon = NSImage(named: NSImage.Name(rawValue: "statusIcon"))
         
+        // Update shared instance of Status Menu Controller
+        // @todo Must be a better way of doing this
+        sharedStatusMenuController = self
+
+        // Update Icons
         icon?.isTemplate = true
         statusItem.image = icon
         runningInBackgroundWindowIcon.image = NSImage(named: NSImage.Name(rawValue: "AppIcon"))

--- a/ballast/StatusMenuController.swift
+++ b/ballast/StatusMenuController.swift
@@ -36,7 +36,7 @@ class StatusMenuController: NSObject {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     let centerBalance: Float32 = 0.5
     let balanceObserver = BalanceObserver()
-    let debouncedCenterDefaultDeviceBalance = Debouncer(.seconds(1))
+    let debouncedCenterDefaultDeviceBalance = Debouncer(.seconds(1.1))
 
     // User Defaults Keys
     let balanceCorrectedKey = "balanceChanged"


### PR DESCRIPTION
<img width="311" alt="screen shot 2018-10-20 at 11 51 30 pm" src="https://user-images.githubusercontent.com/5964236/47256991-17ee3b00-d4c3-11e8-867d-544574885cfb.png">

#5 

## Changes
Updates to add menu option to hide the menu bar icon and keep it running in the background.

Not sure on best practices, but using a hacky approach where we set the menu bar icon visibility to hidden. The app still runs in the background while not cluttering the status menu bar. 

## How to Restore Display of Menu Bar Icon
In order to trigger display of the menu bar icon again:
- Locate `ballast.app` and open (via Finder, Spotlight, Alfred etc.)
- Select from window whether to display icon again

The following window will be displayed:
<img width="576" alt="screen shot 2018-10-20 at 11 58 22 pm" src="https://user-images.githubusercontent.com/5964236/47257081-1a04c980-d4c4-11e8-990a-2c40033962a8.png">

